### PR TITLE
Add notebook environment setup tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# sanzida0202
+
 - 👋 Hi, I’m @sanzida
 - 👀 I’m interested in coding
 - 🌱 I’m currently learning Python
@@ -5,6 +7,28 @@
 - 📫 How to reach me ...
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
+
+## Notebook setup
+
+This repository includes tooling to make it easy to work with Jupyter notebooks.
+
+### Manual setup
+
+1. Ensure you are using Python 3.9 or later.
+2. Create and activate a virtual environment (for example, `python -m venv .venv` followed by `source .venv/bin/activate` on macOS/Linux or `.venv\\Scripts\\activate` on Windows).
+3. Upgrade `pip` inside the environment: `python -m pip install --upgrade pip`.
+4. Install the dependencies listed in [requirements.txt](requirements.txt): `pip install -r requirements.txt`. This will also install JupyterLab, which can alternatively be installed directly with `pip install jupyterlab`.
+5. Launch JupyterLab from the repository root with `jupyter lab` and open your notebooks from there.
+
+### Quick start script
+
+If you prefer an automated setup, run the helper script from the repository root:
+
+```bash
+./scripts/setup_env.sh
+```
+
+The script creates (or reuses) a `.venv` virtual environment, installs the dependencies from `requirements.txt`, and starts JupyterLab with the repository as the working directory.
 
 <!---
 sanzida0202/sanzida0202 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Core Python dependencies required to work with the project's notebooks.
+jupyterlab==4.1.5

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Bootstrap a Python virtual environment for the notebooks and launch JupyterLab.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$PROJECT_ROOT/.venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating virtual environment at $VENV_DIR"
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -r "$PROJECT_ROOT/requirements.txt"
+
+exec jupyter lab --notebook-dir="$PROJECT_ROOT"


### PR DESCRIPTION
## Summary
- add a requirements.txt describing the JupyterLab dependency for working with notebooks
- document manual notebook environment setup instructions, including installing JupyterLab, in the README
- provide a helper script that provisions a virtual environment, installs dependencies, and launches JupyterLab

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc43143b788325b979715ed6b963c6